### PR TITLE
ci: harden dependency restore and token defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Restore portable runtime
-        run: dotnet restore GameAgentRuntime.sln
+        run: dotnet restore GameAgentRuntime.sln --locked-mode
       - name: Build portable runtime
         run: >-
           dotnet build GameAgentRuntime.sln -c Release

--- a/.github/workflows/trusted-source-privacy.yml
+++ b/.github/workflows/trusted-source-privacy.yml
@@ -11,6 +11,8 @@ concurrency:
   group: trusted-release-gate-${{ github.event.workflow_run.id }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
   DOTNET_NOLOGO: "1"
@@ -218,7 +220,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Restore portable runtime
-        run: dotnet restore GameAgentRuntime.sln
+        run: dotnet restore GameAgentRuntime.sln --locked-mode
       - name: Build portable runtime
         run: >-
           dotnet build GameAgentRuntime.sln -c Release


### PR DESCRIPTION
## Summary

- enforce NuGet lock files in both ordinary and trusted .NET restore gates
- default the privileged trusted workflow token to no permissions, preserving only explicit per-job grants

## Verification

- Release version consistency check
- Release version consistency self-test
- Trusted workflow contract self-test
- locked-mode solution restore
- clean diff validation