### PR TITLE
ci: harden dependency restore and token defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Restore portable runtime
-        run: dotnet restore GameAgentRuntime.sln
+        run: dotnet restore GameAgentRuntime.sln --locked-mode
       - name: Build portable runtime
         run: >-
           dotnet build GameAgentRuntime.sln -c Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/trusted-source-privacy.yml
+++ b/.github/workflows/trusted-source-privacy.yml
@@ -11,6 +11,8 @@ concurrency:
   group: trusted-release-gate-${{ github.event.workflow_run.id }}
   cancel-in-progress: true
 
+permissions: {}
+
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
   DOTNET_NOLOGO: "1"
@@ -218,7 +220,7 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Restore portable runtime
-        run: dotnet restore GameAgentRuntime.sln
+        run: dotnet restore GameAgentRuntime.sln --locked-mode
       - name: Build portable runtime
         run: >-
           dotnet build GameAgentRuntime.sln -c Release

--- a/tests/GameAgent.Persistence.Tests/DurableAgentRuntimeTests.cs
+++ b/tests/GameAgent.Persistence.Tests/DurableAgentRuntimeTests.cs
@@ -6410,12 +6410,17 @@ public sealed class DurableAgentRuntimeTests
                 maxProviderAttempts: 2,
                 delay);
             var run = Run(clock.UtcNow);
-            run.Budget.MaxDurationMs = 500;
+            run.Budget.MaxDurationMs = 2_000;
 
-            var outcome = await runtime.RunAsync(
+            var running = runtime.RunAsync(
                     new DurableRunRequest { Run = run }, cancellationToken: TestContext.Current.CancellationToken)
-                .AsTask()
-                .WaitAsync(TimeSpan.FromSeconds(3), cancellationToken: TestContext.Current.CancellationToken);
+                .AsTask();
+            await delay.Started.Task.WaitAsync(
+                TestWaitTimeout,
+                cancellationToken: TestContext.Current.CancellationToken);
+            var outcome = await running.WaitAsync(
+                TimeSpan.FromSeconds(10),
+                cancellationToken: TestContext.Current.CancellationToken);
 
             Assert.Equal(RunStates.BudgetExhausted, outcome.Run.State);
             Assert.Equal("max_duration", outcome.Run.TerminalReason);
@@ -6937,6 +6942,9 @@ public sealed class DurableAgentRuntimeTests
 
             second.Release();
             await second.Settled.WaitAsync(TestWaitTimeout, cancellationToken: TestContext.Current.CancellationToken);
+            Assert.True(
+                await WaitUntilAsync(
+                    () => runtime.DetachedProviderCleanupCount == 1));
             var next = runtime.RunAsync(
                     new DurableRunRequest { Run = Run(clock.UtcNow) }, cancellationToken: TestContext.Current.CancellationToken)
                 .AsTask();


### PR DESCRIPTION
## Summary

- enforce NuGet lock files in both ordinary and trusted .NET restore gates
- default the privileged trusted workflow token to no permissions, preserving only explicit per-job grants
- remove two timing races exposed by simultaneous Windows/Linux CI: wait for the intended deadline stage and for detached-provider cleanup accounting
- use GitHub-signed and verified commits so the protected branch never needs an administrator bypass

## Verification

- Release version consistency check and self-test
- Trusted workflow contract self-test
- locked-mode solution restore
- focused race tests: 20/20 repeated rounds passed
- complete persistence suite: 511/511 passed
- solution formatting verification passed
- full GitHub CI, engines, CodeQL, dependencies, and trusted artifact matrix required before auto-merge