### PR TITLE
Add official branding and attribution guidance

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,5 +37,10 @@
       Pack="true"
       PackagePath=""
       Visible="false" />
+    <None
+      Include="$(MSBuildThisFileDirectory)NOTICE"
+      Pack="true"
+      PackagePath=""
+      Visible="false" />
   </ItemGroup>
 </Project>

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+OpenGameAgent
+Copyright 2026 Eric Sun
+
+This product includes software developed by the OpenGameAgent project.
+Project website: https://opengameagent.com

--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
-# OpenGameAgent
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/brand/opengameagent-mark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/brand/opengameagent-mark-light.svg">
+    <img src="docs/brand/opengameagent-mark-light.svg" alt="OpenGameAgent OGA monogram" width="112">
+  </picture>
+</p>
 
-[简体中文](README.zh-CN.md)
+<h1 align="center">OpenGameAgent</h1>
 
-**Pi for games. Give every NPC a Codex-style action loop, not just ChatGPT-style dialogue.**
+<p align="center"><strong>Pi for games. Give every NPC a Codex-style action loop, not just ChatGPT-style dialogue.</strong></p>
+
+<p align="center"><a href="README.zh-CN.md">简体中文</a></p>
 
 OpenGameAgent is a compact, hackable C# agent runtime for AI-native games, autonomous NPCs, and interactive worlds in Godot, Unity, or .NET services. An NPC can observe structured game state, plan, call game tools, inspect authoritative results, remember, and continue working—not merely generate the next line of dialogue.
 
-[![CI](https://github.com/EricSun0218/OpenGameAgent/actions/workflows/ci.yml/badge.svg)](https://github.com/EricSun0218/OpenGameAgent/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-alpha-orange.svg)](CHANGELOG.md)
+<p align="center">
+  <a href="https://github.com/EricSun0218/OpenGameAgent/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/EricSun0218/OpenGameAgent/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
+  <a href="CHANGELOG.md"><img alt="Status: alpha" src="https://img.shields.io/badge/status-alpha-orange.svg"></a>
+</p>
 
 Like Pi, OpenGameAgent starts with a small, composable agent kernel. It brings that model to game development: the stateful core streams model output, executes validated tools, accepts steering while running, and continues the model/tool loop until work is complete. Use that kernel by itself, add the game layer for game time and durable state, then opt into extension packages for memory, goals, host-verified task plans, artifacts, delegation, external tools, structured interaction, and workflow graphs.
 
@@ -220,6 +230,10 @@ Real-editor gates are documented in [Engine integration](docs/engine-integration
 ## Project boundary
 
 This repository is a developer framework. It does not define a universal character sheet, combat model, world-package format, visual editor, or end-user game. Those belong to each game. The framework provides the agent loop and game-aware primitives needed to build conversational characters, autonomous companions, social simulations, AI directors, generated quests and items, strategy agents, construction agents, and persistent interactive worlds.
+
+## Attribution
+
+OpenGameAgent is licensed under Apache-2.0. An in-game logo or credit is not required, but games and mods are welcome to write **“Powered by OpenGameAgent | opengameagent.com”** in Credits, About, or third-party notices. Preserve [LICENSE](LICENSE) and [NOTICE](NOTICE) when the license requires it. See the [brand assets and usage guidance](docs/brand/README.md).
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,14 +1,24 @@
-# OpenGameAgent
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/brand/opengameagent-mark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="docs/brand/opengameagent-mark-light.svg">
+    <img src="docs/brand/opengameagent-mark-light.svg" alt="OpenGameAgent OGA monogram" width="112">
+  </picture>
+</p>
 
-[English](README.md)
+<h1 align="center">OpenGameAgent</h1>
 
-**游戏版 Pi：让每个 NPC 都拥有类似 Codex 的行动循环，而不只是像 ChatGPT 一样聊天。**
+<p align="center"><strong>游戏版 Pi：让每个 NPC 都拥有类似 Codex 的行动循环，而不只是像 ChatGPT 一样聊天。</strong></p>
+
+<p align="center"><a href="README.md">English</a></p>
 
 OpenGameAgent 是一个紧凑、可修改的 C# Agent Runtime，用于在 Godot、Unity 或 .NET 服务端构建 AI 原生游戏、自主 NPC 与互动世界。NPC 可以观察结构化游戏状态、制定计划、调用游戏工具、检查权威执行结果、形成记忆并继续完成任务，而不只是生成下一句对话。
 
-[![CI](https://github.com/EricSun0218/OpenGameAgent/actions/workflows/ci.yml/badge.svg)](https://github.com/EricSun0218/OpenGameAgent/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
-[![Status](https://img.shields.io/badge/status-alpha-orange.svg)](CHANGELOG.md)
+<p align="center">
+  <a href="https://github.com/EricSun0218/OpenGameAgent/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/EricSun0218/OpenGameAgent/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
+  <a href="CHANGELOG.md"><img alt="Status: alpha" src="https://img.shields.io/badge/status-alpha-orange.svg"></a>
+</p>
 
 与 Pi 一样，OpenGameAgent 从小型、可组合的 Agent 内核出发，并把这种模式带进游戏开发。它的有状态核心会流式接收模型输出、执行经过校验的工具、在运行中接受 steering，并持续进行模型/工具循环直到任务结束。开发者既可以只使用这个内核，也可以叠加游戏层获得游戏时间与可靠状态，再按需加入记忆、目标、宿主证据校验的任务清单、产物、委派、外部工具、结构化交互和工作流图等扩展。
 
@@ -219,6 +229,10 @@ dotnet test OpenGameAgent.sln -c Release --no-build --no-restore
 ## 项目边界
 
 这是面向开发者的框架，不是通用人物卡、战斗系统、世界包格式、可视化编辑器或 C 端游戏。具体玩法属于每一个游戏。框架提供构建对话角色、自主伙伴、社会模拟、AI 导演、动态任务与道具、策略 Agent、建造 Agent 和持续互动世界所需的 Agent Loop 与游戏原语。
+
+## 署名
+
+OpenGameAgent 使用 Apache-2.0 许可证，不强制游戏展示 Logo 或额外署名。我们欢迎游戏和 Mod 在 Credits、关于或第三方许可中写上：**“Powered by OpenGameAgent | opengameagent.com”**，或 **“本游戏使用 OpenGameAgent 构建游戏角色的 Agent 能力。”** 在许可证要求的情况下，请保留 [LICENSE](LICENSE) 和 [NOTICE](NOTICE)。Logo 与品牌使用方式见[品牌资源说明](docs/brand/README.md)。
 
 ## 协议
 

--- a/docs/brand/README.md
+++ b/docs/brand/README.md
@@ -1,0 +1,25 @@
+# OpenGameAgent brand assets
+
+The OGA monogram is the official project mark. Use the theme-aware SVG pair for interfaces that support light and dark color schemes:
+
+- `opengameagent-mark.svg` uses light strokes for dark backgrounds;
+- `opengameagent-mark-light.svg` uses dark strokes for light backgrounds;
+- `opengameagent-mark-mono.svg` is the single-color version for print or constrained surfaces.
+
+Keep the mark's aspect ratio, colors, and clear space intact. Use the OpenGameAgent name and mark for truthful attribution, and do not present a modified build, game, or integration as an official OpenGameAgent release or endorsement.
+
+## Recommended credit
+
+Credit is appreciated but is not an additional condition of the Apache License 2.0. Games and mods may use either of these lines in Credits, About, or third-party notices:
+
+> Powered by OpenGameAgent | opengameagent.com
+
+> 本游戏使用 OpenGameAgent 构建游戏角色的 Agent 能力。
+
+The credit may be plain text; displaying the logo in a shipped game is optional.
+
+## License and notices
+
+OpenGameAgent source code is licensed under the [Apache License 2.0](../../LICENSE). Redistributors must satisfy that license, including preserving the license and the repository's [NOTICE](../../NOTICE) where applicable. Dependencies and optional providers remain subject to their respective licenses; distributors are responsible for reviewing the licenses of the packages and assets included in their final build.
+
+These brand recommendations do not add a mandatory in-game display requirement and do not modify the Apache License 2.0. The license does not grant permission to use project names or marks to imply endorsement of a derived product.

--- a/docs/brand/opengameagent-mark-light.svg
+++ b/docs/brand/opengameagent-mark-light.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">OpenGameAgent</title>
+  <desc id="desc">The OGA monogram. O and G share the outer world boundary, with A at the center.</desc>
+  <g fill="none" stroke-linecap="square" stroke-linejoin="miter">
+    <path d="M45.5 8H20L8 20v24l12 12h24l12-12V32H39.5" stroke="#0A0D0F" stroke-width="7" />
+    <path d="M56 32H45" stroke="#DE593C" stroke-width="7" />
+    <path d="M23.5 44 32 20l8.5 24M27 35h10" stroke="#0A0D0F" stroke-width="5" />
+  </g>
+</svg>

--- a/docs/brand/opengameagent-mark-mono.svg
+++ b/docs/brand/opengameagent-mark-mono.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">OpenGameAgent</title>
+  <desc id="desc">The monochrome OGA monogram.</desc>
+  <g fill="none" stroke="#0A0D0F" stroke-linecap="square" stroke-linejoin="miter">
+    <path d="M45.5 8H20L8 20v24l12 12h24l12-12V32H39.5" stroke-width="7" />
+    <path d="M56 32H45" stroke-width="7" />
+    <path d="M23.5 44 32 20l8.5 24M27 35h10" stroke-width="5" />
+  </g>
+</svg>

--- a/docs/brand/opengameagent-mark.svg
+++ b/docs/brand/opengameagent-mark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title id="title">OpenGameAgent</title>
+  <desc id="desc">The OGA monogram. O and G share the outer world boundary, with A at the center.</desc>
+  <g fill="none" stroke-linecap="square" stroke-linejoin="miter">
+    <path d="M45.5 8H20L8 20v24l12 12h24l12-12V32H39.5" stroke="#EEE9DC" stroke-width="7" />
+    <path d="M56 32H45" stroke="#DE593C" stroke-width="7" />
+    <path d="M23.5 44 32 20l8.5 24M27 35h10" stroke="#EEE9DC" stroke-width="5" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add the official OGA monogram assets for light, dark, and monochrome use
- render the mark at the top of both README files with GitHub theme switching
- document recommended, optional game and mod attribution without adding license obligations
- add Apache-2.0 NOTICE handling to NuGet packages

## Verification
- GitHub Markdown API rendered both README files with picture sources, heading, and badges intact
- source and repository SVG SHA-256 hashes match exactly
- Release build: 0 warnings, 0 errors
- Release tests: 848 passed
- packed NuGet smoke: LICENSE and NOTICE present