### PR TITLE
Remove registry install claims until publishing resumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,17 @@ The kernel boundary is intentionally small and designed to stabilize early. New 
 
 ## Install
 
-Install the complete game runtime from NuGet:
+Download versioned package artifacts, Godot and Unity archives, or the portable server from the [Releases](https://github.com/EricSun0218/OpenGameAgent/releases) page. For active development against a source checkout, reference only the projects your game needs:
 
-```bash
-dotnet add package OpenGameAgent --version 0.3.0-alpha.2
-dotnet add package OpenGameAgent.Memory --version 0.3.0-alpha.2 # optional semantic memory
-dotnet add package OpenGameAgent.Attachments.Local --version 0.3.0-alpha.2 # optional durable image input
+```xml
+<ItemGroup>
+  <ProjectReference Include="path/to/OpenGameAgent/src/OpenGameAgent/OpenGameAgent.csproj" />
+  <ProjectReference Include="path/to/OpenGameAgent/src/OpenGameAgent.Memory/OpenGameAgent.Memory.csproj" />
+  <ProjectReference Include="path/to/OpenGameAgent/src/OpenGameAgent.Attachments.Local/OpenGameAgent.Attachments.Local.csproj" />
+</ItemGroup>
 ```
 
-The kernel, persistence, providers, and engine-compatible client are also published as separate `OpenGameAgent.*` packages. Godot, Unity, and portable server archives are available on the [Releases](https://github.com/EricSun0218/OpenGameAgent/releases) page. See [Getting started](docs/getting-started.md) and [Engine integration](docs/engine-integration.md) before connecting a game.
+Adjust the paths relative to your game project and omit optional projects you do not use. The kernel, persistence, providers, memory, attachments, plugins, and engine-compatible client are also shipped as separate `OpenGameAgent.*` release artifacts. See [Getting started](docs/getting-started.md) and [Engine integration](docs/engine-integration.md) before connecting a game.
 
 ## Why game-specific?
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,15 +52,17 @@ OpenGameAgent 不绑定任何模型或 Provider。角色通过开发者定义的
 
 ## 安装
 
-从 NuGet 安装完整的游戏 Runtime：
+可以从 [Releases](https://github.com/EricSun0218/OpenGameAgent/releases) 下载版本化包文件、Godot/Unity 压缩包或可移植服务端。若游戏需要持续跟随本地最新源码，请只引用实际使用的项目：
 
-```bash
-dotnet add package OpenGameAgent --version 0.3.0-alpha.2
-dotnet add package OpenGameAgent.Memory --version 0.3.0-alpha.2 # 可选语义记忆
-dotnet add package OpenGameAgent.Attachments.Local --version 0.3.0-alpha.2 # 可选持久图片输入
+```xml
+<ItemGroup>
+  <ProjectReference Include="path/to/OpenGameAgent/src/OpenGameAgent/OpenGameAgent.csproj" />
+  <ProjectReference Include="path/to/OpenGameAgent/src/OpenGameAgent.Memory/OpenGameAgent.Memory.csproj" />
+  <ProjectReference Include="path/to/OpenGameAgent/src/OpenGameAgent.Attachments.Local/OpenGameAgent.Attachments.Local.csproj" />
+</ItemGroup>
 ```
 
-内核、持久化、模型提供方和引擎兼容客户端也分别提供 `OpenGameAgent.*` 包。Godot、Unity 与可移植服务端压缩包可以从 [Releases](https://github.com/EricSun0218/OpenGameAgent/releases) 页面下载。接入游戏前请阅读[快速开始](docs/getting-started.md)和[引擎接入](docs/engine-integration.md)。
+请根据游戏项目的位置调整相对路径，并删除没有使用的可选项目引用。内核、持久化、模型提供方、记忆、图片附件、插件和引擎兼容客户端也分别提供 `OpenGameAgent.*` Release 产物。接入游戏前请阅读[快速开始](docs/getting-started.md)和[引擎接入](docs/engine-integration.md)。
 
 ## 为什么要做游戏专用层
 

--- a/docs/agent-plugins.md
+++ b/docs/agent-plugins.md
@@ -29,10 +29,12 @@ Legacy HTTP+SSE is optional in Agent Plugins 1.0.0 and is not implemented. Its e
 
 ## Load and compose
 
-Install the optional adapter package alongside the core runtime:
+From a source checkout, reference the optional adapter project alongside the core runtime. A matching versioned package artifact is also available on the GitHub Releases page.
 
-```powershell
-dotnet add package OpenGameAgent.Plugins --version 0.3.0-alpha.2
+```xml
+<ItemGroup>
+  <ProjectReference Include="path/to/OpenGameAgent/src/OpenGameAgent.Plugins/OpenGameAgent.Plugins.csproj" />
+</ItemGroup>
 ```
 
 ```csharp

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -102,11 +102,7 @@ Context is treated as data, not as a hidden state mutation channel.
 
 ## Add image observations
 
-For screenshots or visual tool results, mount an `IGameImageAttachmentStore` and pass inline image bytes through `GameInput.Content`. The runtime validates and persists the whole batch, saves only immutable references in the transcript, preflights the selected model, and resolves bytes just before provider dispatch.
-
-```powershell
-dotnet add package OpenGameAgent.Attachments.Local --version 0.3.0-alpha.2
-```
+For screenshots or visual tool results, mount an `IGameImageAttachmentStore` and pass inline image bytes through `GameInput.Content`. The runtime validates and persists the whole batch, saves only immutable references in the transcript, preflights the selected model, and resolves bytes just before provider dispatch. Reference `src/OpenGameAgent.Attachments.Local/OpenGameAgent.Attachments.Local.csproj` from a source checkout, or use its matching package artifact from the GitHub Release.
 
 ```csharp
 using OpenGameAgent.Attachments;
@@ -195,11 +191,7 @@ For game-specific selection, use `skill.json` with `id`, `name`, optional `input
 
 The directory loader scans nested skill folders, rejects paths that escape the selected skill directory, and loads instructions only for selected skills. Imported instructions are untrusted content; they do not install code or grant tool permission.
 
-To consume a portable Agent Plugins 1.0.0 package instead of a standalone skill directory, install `OpenGameAgent.Plugins` and load the package as one runtime extension:
-
-```powershell
-dotnet add package OpenGameAgent.Plugins --version 0.3.0-alpha.2
-```
+To consume a portable Agent Plugins 1.0.0 package instead of a standalone skill directory, reference `src/OpenGameAgent.Plugins/OpenGameAgent.Plugins.csproj` from a source checkout, or use its matching package artifact from the GitHub Release, then load the package as one runtime extension:
 
 ```csharp
 using OpenGameAgent.Plugins;

--- a/engines/unity/Packages/com.opengameagent.runtime/CHANGELOG.md
+++ b/engines/unity/Packages/com.opengameagent.runtime/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.3.0-alpha.2
 
-- Add the optional source/NuGet vector-memory package and authoritative memory snapshot contract.
+- Add the optional vector-memory package and authoritative memory snapshot contract.
 
 ## 0.3.0-alpha.1
 


### PR DESCRIPTION
## Summary
- replace public registry install commands with GitHub Release assets and source project references
- keep English and Chinese READMEs aligned
- remove the stale registry wording from plugin, getting-started, and Unity package docs

## Verification
- ./tools/Test-PublicTree.ps1 (378 paths)
- public Markdown contains no NuGet or dotnet add package references