### PR TITLE
Update CodeQL init action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
           DOTNET_INSTALL_DIR: ${{ runner.temp }}/.dotnet
         with:
           global-json-file: global.json
-      - uses: github/codeql-action/init@24c7eb380a2dc368f2d129e4c65e51d172983a1e # v4
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: csharp
           build-mode: manual


### PR DESCRIPTION
## Summary

- update `github/codeql-action/init` to the same pinned v4.37.6 commit already used by `analyze`;
- replace #18, which Dependabot auto-closed after #16 even though the `init` occurrence remained on the old SHA.

## Scope

One workflow reference in `.github/workflows/codeql.yml`; no runtime or package code changes.

## Validation

- `git diff --check`
- the updated #18 branch previously completed Windows, Linux, engine package, dependency review, and CodeQL checks successfully; this replacement PR must run the same required checks again before merge.