### PR TITLE
Prepare alpha.3 engine store packages

### DIFF
--- a/engines/godot/addons/open_game_agent/plugin.cfg
+++ b/engines/godot/addons/open_game_agent/plugin.cfg
@@ -3,5 +3,5 @@
 name="OpenGameAgent"
 description="Provider-neutral agent runtime for AI-native Godot games."
 author="Eric Sun"
-version="0.3.0-alpha.2"
+version="0.3.0-alpha.3"
 script="plugin.gd"

--- a/engines/unity/Packages/com.opengameagent.runtime/CHANGELOG.md
+++ b/engines/unity/Packages/com.opengameagent.runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.0-alpha.3
+
+- Add a deterministic no-key sample and store-ready package metadata.
+- Add complete third-party notices for bundled runtime dependencies.
+- Validate the sample in a real Unity 6 editor smoke test.
+
 ## 0.3.0-alpha.2
 
 - Add the optional vector-memory package and authoritative memory snapshot contract.

--- a/engines/unity/Packages/com.opengameagent.runtime/package.json
+++ b/engines/unity/Packages/com.opengameagent.runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.opengameagent.runtime",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "displayName": "OpenGameAgent",
   "description": "A provider-neutral agent runtime for AI-native Unity games, with local and server-hosted execution, structured context, tools, streaming, steering, and multi-actor coordination.",
   "unity": "6000.0",


### PR DESCRIPTION
Bumps the Godot and Unity store package manifests to 0.3.0-alpha.3 and records the store-readiness changes.\n\nVerified locally:\n- Unity package gate (Unity 6000.5.6f1 references)\n- Godot package gate (Godot 4.7.1 .NET references)\n- Store listing gate\n- git diff --check