### PR TITLE
docs(unity): mark OpenUPM package available

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Unity 6 projects can install the complete `0.3.0-alpha.3` package directly from 
 https://github.com/EricSun0218/OpenGameAgent.git#upm/0.3.0-alpha.3
 ```
 
-After the package is indexed by OpenUPM, it can also be installed with `openupm add com.opengameagent.runtime@0.3.0-alpha.3`. The generated `upm` branch contains the tested binaries; the Unity source directory on `main` is not itself a distributable package.
+The same release is available through OpenUPM: `openupm add com.opengameagent.runtime@0.3.0-alpha.3`. The generated `upm` branch contains the tested binaries; the Unity source directory on `main` is not itself a distributable package.
 
 ```xml
 <ItemGroup>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ Unity 6 项目可以直接通过不可变的 GitHub UPM tag 安装完整的 `0.3
 https://github.com/EricSun0218/OpenGameAgent.git#upm/0.3.0-alpha.3
 ```
 
-OpenUPM 完成索引后，也可以执行 `openupm add com.opengameagent.runtime@0.3.0-alpha.3`。自动生成的 `upm` 分支包含经过测试的完整二进制；`main` 上的 Unity 源码目录本身不是可分发包。
+同一版本也已发布到 OpenUPM，可执行 `openupm add com.opengameagent.runtime@0.3.0-alpha.3` 安装。自动生成的 `upm` 分支包含经过测试的完整二进制；`main` 上的 Unity 源码目录本身不是可分发包。
 
 ```xml
 <ItemGroup>

--- a/engines/unity/Packages/com.opengameagent.runtime/README.md
+++ b/engines/unity/Packages/com.opengameagent.runtime/README.md
@@ -10,7 +10,7 @@ Install the immutable GitHub UPM release from **Window > Package Manager > + > A
 https://github.com/EricSun0218/OpenGameAgent.git#upm/0.3.0-alpha.3
 ```
 
-Or install from OpenUPM after the package is listed:
+Or install the same release from OpenUPM:
 
 ```bash
 openupm add com.opengameagent.runtime@0.3.0-alpha.3


### PR DESCRIPTION
## Summary
- mark the Unity package as available through OpenUPM
- keep English, Chinese, and package-local installation text aligned

## Verification
- `./tools/Test-PublicTree.ps1`
- `./tools/Test-StoreListings.ps1`
- `npm view com.opengameagent.runtime version --registry https://package.openupm.com`